### PR TITLE
Add postgres to compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN python3 -m build ge_sdk
 RUN pip install ge_sdk/dist/ge_sdk-1.0.0-py3-none-any.whl
 
 COPY ./ ./
+
+CMD ["/bin/bash", "-c", "([ -d 'migrations' ] || flask db init) && flask db migrate && flask db upgrade && python3 server.py"]

--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
   game-engine:
     build: ./
     ports:
-      - 80:4000
+      - 4000:4000
     depends_on:
       - postgres
       - redis

--- a/compose.yml
+++ b/compose.yml
@@ -1,30 +1,32 @@
-version: "3"
-
 services:
-
   redis:
-    image: "redis"
-
+    image: redis:7-alpine
     command: redis-server
-
     ports:
       - 6379:6379
-
     networks:
       local-network:
         ipv4_address: 172.28.1.4
 
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: game-engine
+    ports:
+      - 5432:5432
+    networks:
+      local-network:
+        ipv4_address: 172.28.1.5
+
   game-engine:
     build: ./
-
-    command: python3 server.py 
-    
     ports:
-      - 4000:4000
-
+      - 80:4000
     depends_on:
+      - postgres
       - redis
-
     networks:
       - local-network
 

--- a/config.py.example
+++ b/config.py.example
@@ -1,6 +1,6 @@
 DB_LOGIN = "postgres"
-DB_PASSWORD = ""
-DB_HOST = "localhost"
+DB_PASSWORD = "postgres"
+DB_HOST = "172.28.1.5"
 DB_PORT = 5432
 DB_DATABASE = "game-engine"
 


### PR DESCRIPTION
# Hey there, this might be of use

## Changelog

### Some loony trickery first:
- Rename `docker-compose.yml` to `compose.yml`
- Remove `version` from `compose.yml`
- Move `command` from `compose.yml` to `CMD` in `Dockerfile`
- Terminate `Dockerfile` with a newline
- Terminate `config.py.example` with a newline

### The good stuff now:
- Add `flask db` `init`, `migrate`, `upgrade` to `CMD` in `Dockerfile`
- Add `postgres` service to `compose.yml` and connect it to `local-network`
- Change `DB_PASSWORD` and `DB_HOST` in `config.py.example`
- Change Docker images to the lighter `alpine` versions
- Pin major Docker image version tags: `redis:7-alpine` and `postgres:16-alpine`